### PR TITLE
breaking: Update `Scriban` to v6.2.1, update other pkg

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,12 +16,12 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     env:
-      version: '2.1.0'
-      versionFile: '2.1.0'
+      version: '3.0.0'
+      versionFile: '3.0.0'
       packDotNetVersion: '8'
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         dotnet-version: [ '3.x', '6.x', '8.0' ]
 
     steps:

--- a/Src/Axuno.TextTemplating.Tests/Axuno.TextTemplating.Tests.csproj
+++ b/Src/Axuno.TextTemplating.Tests/Axuno.TextTemplating.Tests.csproj
@@ -16,11 +16,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)'=='net8.0'" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)'!='net8.0'"/>
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Src/Axuno.TextTemplating/Axuno.TextTemplating.csproj
+++ b/Src/Axuno.TextTemplating/Axuno.TextTemplating.csproj
@@ -41,17 +41,17 @@ The library is a modified version of the lightweight TextTemplating.Scriban part
       <IncludeSymbols>true</IncludeSymbols>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Axuno.VirtualFileSystem" Version="2.1.0" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.6" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.6" />
+      <PackageReference Include="Axuno.VirtualFileSystem" Version="2.2.0" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.6" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Scriban.Signed" Version="5.10.0" />
-      <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+      <PackageReference Include="Scriban.Signed" Version="6.2.1" />
+      <PackageReference Include="System.Collections.Immutable" Version="9.0.6" />
     </ItemGroup>
     <ItemGroup>
       <None Include="..\..\TextTemplating.png">

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <Product>Axuno.TextTemplating</Product>
-        <Version>2.0.1</Version>
-        <FileVersion>2.0.1</FileVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
+        <Version>3.0.0</Version>
+        <FileVersion>3.0.0</FileVersion>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <Company>axuno gGmbH</Company>
         <Authors>axuno gGmbH</Authors>
         <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>

--- a/Src/TextTemplatingDemo/TextTemplatingDemo.csproj
+++ b/Src/TextTemplatingDemo/TextTemplatingDemo.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**Library Project:**
- Scriban.Signed v5.10.0 -> 6.2.1 (breaking)
- Axuno.VirtualFileSystem v2.1.0 -> 2.2.0
- Microsoft.Extensions.FileProviders.Composite v8.0.0 -> v9.0.6
- Microsoft.Extensions.FileProviders.Embedded v8.0.6 -> v9.0.6
- Microsoft.Extensions.FileProviders.Physical v8.0.6 -> v9.0.6
- Microsoft.Extensions.Localization v8.0.6 -> v9.0.6
- System.Collections.Immutable v8.0.6 -> v9.0.6

**Unit Tests:**
- Microsoft.NET.Test.Sdk v17.10.0 -> v17.14.1
- Microsoft.Extensions.DependencyInjection v8.0.0 -> 9.0.6
- NUnit v4.1.0 -> v4.3.2
- NUnit3TestAdapter v4.5.0 -> v5.0.0
- NUnit.Analyzers v4.2.0 -> 4.9.2

Bump version to `v3.0.0`

**CI Build**
Update `build_test.yml` to use `ubuntu-22.04` instead of `ubuntu-latest` because of missing libssl failure with `ubuntu-24.04`