### PR TITLE
Supported TFM are now `netstandard2.1` and `net8.0`, dropped `net6.0`

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        dotnet-version: [ '3.x', '6.x', '8.0' ]
+        dotnet-version: [ '3.x', '8.0' ]
 
     steps:
     - name: Checkout

--- a/Src/Axuno.TextTemplating.Tests/Axuno.TextTemplating.Tests.csproj
+++ b/Src/Axuno.TextTemplating.Tests/Axuno.TextTemplating.Tests.csproj
@@ -16,12 +16,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)'=='net8.0'" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)'!='net8.0'"/>
-        <PackageReference Include="NUnit" Version="4.3.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)'!='net8.0'" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Src/Axuno.TextTemplating/Axuno.TextTemplating.csproj
+++ b/Src/Axuno.TextTemplating/Axuno.TextTemplating.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <Description>Text templating is used to dynamically render contents based on a template and a model.
@@ -42,16 +42,16 @@ The library is a modified version of the lightweight TextTemplating.Scriban part
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Axuno.VirtualFileSystem" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.6" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.6" />
-      <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.6" />
-      <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.9" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.9" />
+      <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.9" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Scriban.Signed" Version="6.2.1" />
-      <PackageReference Include="System.Collections.Immutable" Version="9.0.6" />
+      <PackageReference Include="Scriban.Signed" Version="6.4.0" />
+      <PackageReference Include="System.Collections.Immutable" Version="9.0.9" />
     </ItemGroup>
     <ItemGroup>
       <None Include="..\..\TextTemplating.png">


### PR DESCRIPTION
chore: Updated `Scriban` from v6.2.1 to v6.4.0 and other referenced nuget packages